### PR TITLE
reload if the file changes; display error in status on error

### DIFF
--- a/CommandOnSave.py
+++ b/CommandOnSave.py
@@ -1,20 +1,42 @@
+import os
 import sublime
 import sublime_plugin
 import subprocess
 
 
+_STATUS_KEY = 'CommandOnSave'
+
 class CommandOnSave(sublime_plugin.EventListener):
-    def on_post_save(self, view):
-
+    def on_post_save_async(self, view):
         settings = sublime.load_settings('CommandOnSave.sublime-settings').get('commands')
-        file = view.file_name()
+        if settings is None:
+            return
 
-        if not settings == None:
-            for path in settings.keys():
-                commands = settings.get(path)
-                if file.startswith(path) and len(commands) > 0:
-                    print("Command on Save:")
-                    for command in commands:
-                        p = subprocess.Popen([command], shell=True, stdout=subprocess.PIPE)
-                        out, err = p.communicate()
-                        print (out.decode('utf-8'))
+        file = view.file_name()
+        before_stat = None
+
+        view.erase_status(_STATUS_KEY)
+        for path, commands in settings.items():
+            if file.startswith(path):
+                for command in commands:
+                    # record the mtime so we can check if we need to reload the file
+                    if before_stat is None:
+                        before_stat = os.stat(file)
+
+                    command.append(file)
+                    process = subprocess.Popen(command,
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    output = process.stdout.read()
+                    code = process.wait()
+                    if code != 0:
+                        view.set_status(_STATUS_KEY, 'ERROR: Command failed: %s' % (
+                            ' '.join(command)))
+                        print('CommandOnSave %s failed code %d; output: %s' % (
+                            ' '.join(command), code, output))
+                        # attempt to execute any other commands
+
+        if before_stat is not None and not view.is_dirty():
+            after_stat = os.stat(file)
+            if before_stat.st_mtime != after_stat.st_mtime:
+                # it seems like the file changed: reload the view
+                view.run_command('revert')


### PR DESCRIPTION
This command is useful when we want to apply some sort of automatic
formatting tool on save. In that case, if the file is changed, we want
to reload it. Use the file's mtime to detect this case.

Additionally, if the command fails, we want to display a message. Show
the error in the status bar, as well as logging to the console.

I understand if you don't want to accept this pull request. In particular, I think this is not totally backwards compatible: I'm assuming the configured command is a JSON list, which has the file appended to it then execed. However, if you are interested in pull requests, we can figure out a way to make this configurable!

If not, I'm happy to fork it.