### PR TITLE
Add missing import

### DIFF
--- a/CommandOnSave.py
+++ b/CommandOnSave.py
@@ -2,7 +2,7 @@ import os
 import sublime
 import sublime_plugin
 import subprocess
-
+import re
 
 _STATUS_KEY = 'CommandOnSave'
 


### PR DESCRIPTION
Fix the "global name 're' is not defined" error.