### PR TITLE
Enable running bash commands

### DIFF
--- a/CommandOnSave.py
+++ b/CommandOnSave.py
@@ -30,7 +30,7 @@ class CommandOnSave(sublime_plugin.EventListener):
                     )
                     
                     process = subprocess.Popen(command,
-                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
                     output = process.stdout.read()
                     code = process.wait()
                     if code != 0:


### PR DESCRIPTION
By setting 'shell' to 'True', the command can be any bash command. No need to save to a file and execute as a script.